### PR TITLE
Fix index error in MFCC.java

### DIFF
--- a/src/edu/polyu/mfcc/MFCC.java
+++ b/src/edu/polyu/mfcc/MFCC.java
@@ -180,7 +180,7 @@ public class MFCC {
 				num1 += this.mult[k][i]*bin[i];
 			}
 
-			for (int i = cbin[k]; i <= cbin[k + 1]; i++) {
+			for (int i = cbin[k] + 1; i <= cbin[k + 1]; i++) {
 				//double tmp2 = (double)((double)(cbin[k+1]-i) / (double)(cbin[k + 1] - cbin[k]));
 				//System.out.printf("%d %.3f\n", i, tmp2);
 				num2 += this.mult[k][i]*bin[i];


### PR DESCRIPTION
The index in getFilteroutput should be started from cbin[k] + 1.
Compared this with another library and the correctness is proved.